### PR TITLE
Fix for 'Too Many Files' error because of tempfile.mkstemp

### DIFF
--- a/smush/optimiser/optimiser.py
+++ b/smush/optimiser/optimiser.py
@@ -59,9 +59,12 @@ class Optimiser(object):
         Returns the input file name with Optimiser.output_suffix inserted before the extension
         """
         temp = tempfile.mkstemp(suffix=Optimiser.output_suffix)
-        output_file_name = temp[1]
-        os.unlink(output_file_name)
-        return output_file_name
+        try:
+            output_file_name = temp[1]
+            os.unlink(output_file_name)
+            return output_file_name
+        finally:
+            os.close(temp[0])
 
 
     def __replace_placeholders(self, command, input, output):


### PR DESCRIPTION
I was getting a 'too many files' OSError when running smush.py on Ubuntu 12.04. [tempfile.mkstemp](http://docs.python.org/library/tempfile.html#tempfile.mkstemp) returns an open file handle as well as the file name. This wasn't getting closed causing the script to fallover at (I think) 1024 open temp files. Adding [os.close](http://docs.python.org/library/os.html#os.close) makes the script run without error.
